### PR TITLE
added close function

### DIFF
--- a/lib/connect-databank.js
+++ b/lib/connect-databank.js
@@ -280,12 +280,18 @@ module.exports = function(connect) {
             });
         };
 
+        store.close = function() {
+            var self = this;
+            clearInterval(self.interval);
+            clearTimeout(self.timeout);
+        };
+
         // Set up cleanup to happen every so often.
 
         if (cleanupInterval) {
             // Since there may be multiple processes trying to clean up,
             // We stagger our cleanup randomly somewhere over the interval period
-            setTimeout(function() {
+            store.timeout = setTimeout(function() {
                 var doCleanup = function() {
                     store.cleanup(function(err) {
                         if (err) {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     ],
     "dependencies" : {
         "async": "0.2.x",
-	"underscore":  "1.4.x",
-	"databank":  "0.19.x",
+        "underscore":  "1.4.x",
+        "databank":  "0.19.x",
         "set-immediate": "0.1.x",
         "node-uuid": "1.4.x"
     },


### PR DESCRIPTION
This is needed to stop the timers. When running multiple test (starting and stopping) using connect-databank, the timers will prevent the previous instance from closing causing errors/stalling.